### PR TITLE
feat(apontamento): marcar ordem como retrabalho + persistir ordensProducao

### DIFF
--- a/Main.gs
+++ b/Main.gs
@@ -23,8 +23,34 @@ const VALID_TURNOS = ["TURNO 1", "TURNO 2", "TURNO 3"];
 
 const PROD_HEADERS = [
   "id", "date", "turno", "machineId", "machineName",
-  "meta", "producao", "savedBy", "savedAt", "editUser", "editTime", "obs"
+  "meta", "producao", "savedBy", "savedAt", "editUser", "editTime", "obs",
+  "ordensProducao"
 ];
+
+// Serializa o array de ordens (com flag retrabalho) como JSON string para armazenar na célula.
+// Sanitiza cada campo defensivamente. Retorna "" se não houver ordens válidas.
+function sanitizeOrdensProducao(ordens) {
+  if (!Array.isArray(ordens) || ordens.length === 0) return "";
+  var clean = [];
+  for (var i = 0; i < ordens.length; i++) {
+    var o = ordens[i] || {};
+    var qtd = sanitizeNumber(o.quantidade, 0, 100000);
+    if (qtd <= 0) continue;
+    var item = {
+      ordemId: sanitizeString(o.ordemId || "", 20),
+      quantidade: qtd
+    };
+    if (o.obs) item.obs = sanitizeString(o.obs, 200);
+    if (o.retrabalho === true) item.retrabalho = true;
+    clean.push(item);
+  }
+  if (clean.length === 0) return "";
+  try {
+    return JSON.stringify(clean);
+  } catch (e) {
+    return "";
+  }
+}
 
 const USER_HEADERS = ["nome", "senhaHash", "role", "criadoEm", "status", "loginAttempts", "lockedUntil"];
 const SESSION_HEADERS = ["token", "nome", "role", "createdAt", "expiresAt"];
@@ -1395,7 +1421,9 @@ function actionUpsert(token, records) {
         editUser: sanitizeString(rec.editUser, 50),
         editTime: sanitizeString(rec.editTime, 50),
         // obs: undefined significa "não fornecido — preservar valor existente"
-        obs: rec.obs !== undefined ? sanitizeString(rec.obs, 500) : undefined
+        obs: rec.obs !== undefined ? sanitizeString(rec.obs, 500) : undefined,
+        // ordensProducao: idem — undefined preserva, array reescreve
+        ordensProducao: rec.ordensProducao !== undefined ? sanitizeOrdensProducao(rec.ordensProducao) : undefined
       };
       
       // Procurar registro existente (por posição fixa — igual ao actionGetAll)
@@ -1434,7 +1462,7 @@ function actionUpsert(token, records) {
         }
 
         // Preserva campos do registro original quando não fornecidos na atualização
-        if (foundRow > 0 && (header === "savedBy" || header === "savedAt" || header === "obs")) {
+        if (foundRow > 0 && (header === "savedBy" || header === "savedAt" || header === "obs" || header === "ordensProducao")) {
           const existingIdx = PROD_HEADERS.indexOf(header);
           return existingIdx >= 0 ? (allData[foundRow - 1][existingIdx] || "") : "";
         }
@@ -1632,6 +1660,7 @@ function actionAppend(token, records) {
         if (header === "editUser") return sanitizeString(rec.editUser || "", 50);
         if (header === "editTime") return sanitizeString(rec.editTime || "", 50);
         if (header === "obs") return sanitizeString(rec.obs || "", 500);
+        if (header === "ordensProducao") return sanitizeOrdensProducao(rec.ordensProducao);
         return "";
       });
 

--- a/src/components/FeedbacksTab.tsx
+++ b/src/components/FeedbacksTab.tsx
@@ -216,10 +216,13 @@ const FeedbacksTab = () => {
                       {ordensExpanded.has(key) && (
                         <div className="mt-1.5 pl-2 border-l-2 border-primary/20 space-y-0.5">
                           {r.ordensProducao!.map((o, oi) => (
-                            <p key={oi} className="text-[11px] text-muted-foreground">
+                            <p key={oi} className="text-[11px] text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                              {o.retrabalho && (
+                                <span className="text-[9px] font-extrabold px-1.5 py-px rounded bg-amber-500/90 text-white tracking-wide">RETRABALHO</span>
+                              )}
                               <span className="font-semibold text-foreground">#{o.ordemId}</span>
-                              {" — "}{o.quantidade.toLocaleString("pt-BR")} pç
-                              {o.obs && <span className="text-muted-foreground"> ({o.obs})</span>}
+                              <span>— {o.quantidade.toLocaleString("pt-BR")} pç</span>
+                              {o.obs && <span className="text-muted-foreground">({o.obs})</span>}
                             </p>
                           ))}
                         </div>

--- a/src/components/OrdemProducaoInput.tsx
+++ b/src/components/OrdemProducaoInput.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from "lucide-react";
+import { Trash2, RefreshCw } from "lucide-react";
 import type { OrdemProducao } from "@/lib/api";
 
 interface OrdemProducaoInputProps {
@@ -10,8 +10,12 @@ const OrdemProducaoInput = ({ ordens, onChange }: OrdemProducaoInputProps) => {
   const filledOrdens = ordens.filter(o => o.quantidade > 0);
   const total = filledOrdens.reduce((s, o) => s + o.quantidade, 0);
 
-  function updateOrdem(idx: number, field: keyof OrdemProducao, value: string | number) {
+  function updateOrdem(idx: number, field: keyof OrdemProducao, value: string | number | boolean) {
     onChange(ordens.map((o, i) => i === idx ? { ...o, [field]: value } : o));
+  }
+
+  function toggleRetrabalho(idx: number) {
+    onChange(ordens.map((o, i) => i === idx ? { ...o, retrabalho: !o.retrabalho } : o));
   }
 
   function removeOrdem(idx: number) {
@@ -21,28 +25,45 @@ const OrdemProducaoInput = ({ ordens, onChange }: OrdemProducaoInputProps) => {
 
   return (
     <div className="space-y-2">
-      {ordens.map((ordem, idx) => (
-        <div key={idx} className="flex gap-2 items-center">
+      {ordens.map((ordem, idx) => {
+        const isRetrabalho = !!ordem.retrabalho;
+        return (
+        <div
+          key={idx}
+          className={`flex gap-2 items-center rounded-md transition-colors ${isRetrabalho ? "bg-amber-50 border border-amber-300/60 p-1.5" : ""}`}
+          style={isRetrabalho ? { borderRadius: 8 } : undefined}
+        >
           <input
             type="text"
             placeholder="Nº OS"
             value={ordem.ordemId}
             onChange={e => updateOrdem(idx, "ordemId", e.target.value.slice(0, 20))}
-            className="px-3 py-2 text-sm rounded-md border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-all placeholder:text-muted-foreground/40"
+            className={`px-3 py-2 text-sm rounded-md border bg-background focus:outline-none focus:ring-2 transition-all placeholder:text-muted-foreground/40 ${isRetrabalho ? "border-amber-400/60 focus:ring-amber-400/30 focus:border-amber-500" : "border-border focus:ring-primary/30 focus:border-primary"}`}
             style={{ borderRadius: 6, flex: 1 }}
           />
           <input
             type="number"
             inputMode="numeric"
-            placeholder="Quantidade"
+            placeholder="Qtd"
             min={0}
             max={999999}
             value={ordem.quantidade || ""}
             onChange={e => updateOrdem(idx, "quantidade", Math.max(0, Number(e.target.value)))}
-            className="px-3 py-2 text-sm font-bold rounded-md border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-all placeholder:text-muted-foreground/40 text-center"
+            className={`px-3 py-2 text-sm font-bold rounded-md border bg-background focus:outline-none focus:ring-2 transition-all placeholder:text-muted-foreground/40 text-center ${isRetrabalho ? "border-amber-400/60 focus:ring-amber-400/30 focus:border-amber-500 text-amber-800" : "border-border focus:ring-primary/30 focus:border-primary"}`}
             style={{ borderRadius: 6, flex: 1 }}
           />
           <button
+            type="button"
+            onClick={() => toggleRetrabalho(idx)}
+            aria-pressed={isRetrabalho}
+            className={`shrink-0 w-9 h-9 flex items-center justify-center rounded-md border transition-all ${isRetrabalho ? "bg-amber-500 border-amber-600 text-white shadow-sm" : "bg-muted/40 border-border text-muted-foreground hover:bg-amber-50 hover:border-amber-300 hover:text-amber-600"}`}
+            style={{ borderRadius: 6 }}
+            title={isRetrabalho ? "Marcado como retrabalho — clique pra desmarcar" : "Marcar como retrabalho"}
+          >
+            <RefreshCw size={14} />
+          </button>
+          <button
+            type="button"
             onClick={() => removeOrdem(idx)}
             disabled={ordens.length <= 1}
             className="shrink-0 w-9 h-9 flex items-center justify-center rounded-md text-destructive hover:bg-destructive/10 border border-transparent hover:border-destructive/20 transition-all disabled:opacity-20 disabled:cursor-not-allowed"
@@ -52,7 +73,8 @@ const OrdemProducaoInput = ({ ordens, onChange }: OrdemProducaoInputProps) => {
             <Trash2 size={14} />
           </button>
         </div>
-      ))}
+      );
+      })}
 
       {filledOrdens.length > 1 && (
         <p className="text-xs text-muted-foreground font-medium pt-0.5 text-right">

--- a/src/components/OrdemProducaoInput.tsx
+++ b/src/components/OrdemProducaoInput.tsx
@@ -1,4 +1,4 @@
-import { Trash2, RefreshCw } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import type { OrdemProducao } from "@/lib/api";
 
 interface OrdemProducaoInputProps {
@@ -60,7 +60,7 @@ const OrdemProducaoInput = ({ ordens, onChange }: OrdemProducaoInputProps) => {
             style={{ borderRadius: 6 }}
             title={isRetrabalho ? "Marcado como retrabalho — clique pra desmarcar" : "Marcar como retrabalho"}
           >
-            <RefreshCw size={14} />
+            <span className="text-sm font-extrabold leading-none">R</span>
           </button>
           <button
             type="button"

--- a/src/components/ReportsTab.tsx
+++ b/src/components/ReportsTab.tsx
@@ -510,16 +510,22 @@ const ReportsTab = () => {
                               <td /><td />
                               <td colSpan={8} className="px-4 pb-3 pt-0">
                                 <div className="flex flex-wrap gap-1.5 border-l-2 border-primary/30 pl-3">
-                                  {r.ordensProducao!.map((o, oi) => (
+                                  {r.ordensProducao!.map((o, oi) => {
+                                    const isR = !!o.retrabalho;
+                                    return (
                                     <span key={oi}
-                                      className="inline-flex items-center gap-1 text-[11px] font-semibold px-2.5 py-1 rounded-full border border-primary/20"
-                                      style={{ background: "#0066B310", color: "#0066B3" }}>
+                                      className={`inline-flex items-center gap-1 text-[11px] font-semibold px-2.5 py-1 rounded-full border ${isR ? "border-amber-400/50" : "border-primary/20"}`}
+                                      style={isR
+                                        ? { background: "#F59E0B15", color: "#B45309" }
+                                        : { background: "#0066B310", color: "#0066B3" }}>
+                                      {isR && <span className="text-[9px] font-extrabold px-1 py-px rounded bg-amber-500/90 text-white tracking-wide">RETRABALHO</span>}
                                       <span className="text-muted-foreground font-medium">#{o.ordemId}</span>
-                                      <span className="mx-0.5 text-primary/40">→</span>
+                                      <span className={`mx-0.5 ${isR ? "text-amber-500/50" : "text-primary/40"}`}>→</span>
                                       <span>{o.quantidade.toLocaleString("pt-BR")} pç</span>
                                       {o.obs && <span className="text-muted-foreground ml-1">· {o.obs}</span>}
                                     </span>
-                                  ))}
+                                    );
+                                  })}
                                 </div>
                               </td>
                             </tr>
@@ -794,16 +800,22 @@ const ReportsTab = () => {
                                 <td />
                                 <td colSpan={4} className="px-3 pb-2 pt-0">
                                   <div className="flex flex-wrap gap-1 pl-1 border-l-2 border-primary/20">
-                                    {r.ordensProducao!.map((o, oi) => (
+                                    {r.ordensProducao!.map((o, oi) => {
+                                      const isR = !!o.retrabalho;
+                                      return (
                                       <span
                                         key={oi}
-                                        className="inline-flex items-center text-[10px] font-semibold px-2 py-0.5 rounded-full border border-primary/15"
-                                        style={{ background: "#0066B308", color: "#0066B3" }}
-                                        title={`${o.quantidade.toLocaleString("pt-BR")} pç${o.obs ? ` — ${o.obs}` : ""}`}
+                                        className={`inline-flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full border ${isR ? "border-amber-400/40" : "border-primary/15"}`}
+                                        style={isR
+                                          ? { background: "#F59E0B12", color: "#B45309" }
+                                          : { background: "#0066B308", color: "#0066B3" }}
+                                        title={`${isR ? "RETRABALHO · " : ""}${o.quantidade.toLocaleString("pt-BR")} pç${o.obs ? ` — ${o.obs}` : ""}`}
                                       >
+                                        {isR && <span className="text-[8px] font-extrabold px-1 rounded bg-amber-500/90 text-white">R</span>}
                                         #{o.ordemId} → {o.quantidade.toLocaleString("pt-BR")} pç
                                       </span>
-                                    ))}
+                                      );
+                                    })}
                                   </div>
                                 </td>
                               </tr>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 // ─── API Layer ────────────────────────────────────────────────
-const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbzXvyK0tSitNxSmzt44ENTKID-QdgFHatvaXuWtxLoFBBx4HQmIzZZp7yjWTdvkh2AUAg/exec";
+const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbyeiU8btjcJdhZkv6MRo-_M1jLx7s7YD6GWMfxVB7PIkeoRC5Aiq8FwzJkKgEIbgAz8Ag/exec";
 export const SESSION_KEY = "prod_session_v3";
 const CACHE_KEY = "prod_records_cache";
 const CACHE_METAS_KEY = "prod_metas_cache";

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,7 @@ export interface OrdemProducao {
   ordemId: string;
   quantidade: number;
   obs?: string;
+  retrabalho?: boolean;
 }
 
 export interface ProdRecord {


### PR DESCRIPTION
## Summary

Closes #6.

Adiciona **flag de retrabalho por ordem** no fluxo de apontamento, com persistência ponta-a-ponta. No caminho, conserta um gap silencioso do backend: `ordensProducao` já era enviado pelo frontend mas **não era persistido** — qualquer refresh apagava as ordens detalhadas. Agora sobrevive.

## Mudanças

### Frontend
- **`src/lib/api.ts`** — `OrdemProducao` ganha `retrabalho?: boolean`.
- **`src/components/OrdemProducaoInput.tsx`** — botão toggle (`RefreshCw`) por linha. Quando ativo, a linha inteira fica destacada em âmbar.
- **`src/components/ReportsTab.tsx`** — chips de ordem nos dois modos (calendário expandido + tabela detalhada) ganham badge **RETRABALHO** quando o flag estiver ativo, com paleta âmbar pra contrastar do azul institucional.
- **`src/components/FeedbacksTab.tsx`** — mesmo tratamento na visão expandida de ordens.

### Backend (`Main.gs`)
- **`PROD_HEADERS`** ganha `"ordensProducao"`.
- **`getProdSheet()`** já tinha migração automática de colunas — quando o GAS rodar a primeira vez após o deploy, a coluna nova é adicionada ao header sem trabalho manual.
- **`sanitizeOrdensProducao(ordens)`** — nova função: valida array, sanitiza `ordemId` (max 20), `quantidade` (0–100k), `obs` (max 200), `retrabalho` (booleano), serializa como JSON.
- **`actionUpsert`** e **`actionAppend`** persistem o campo. No upsert, preserva o valor existente quando o payload não traz `ordensProducao` (mesmo padrão de `obs`).

## Como testar

1. **Apontar:** abrir uma máquina, adicionar uma ordem, clicar no botão âmbar (RefreshCw) — a linha inteira fica destacada. Salvar.
2. **Histórico:** a ordem aparece com o badge laranja "RETRABALHO" no calendário e na tabela.
3. **Feedbacks:** mesmo tratamento na visão expandida.
4. **Refresh do navegador:** o flag persiste (antes nem o `ordensProducao` sobrevivia — esse PR resolve isso).

## Deploy

⚠️ Backend (`Main.gs`) precisa ser **redesployed no Google Apps Script** pra mudança ficar ativa. A coluna nova é adicionada automaticamente ao sheet na primeira execução pós-deploy — não requer migração manual.

## Test plan

- [ ] Marcar uma ordem como retrabalho → linha destaca em âmbar
- [ ] Salvar → toast de sucesso
- [ ] Refresh → flag mantido
- [ ] Verificar badge nas views Histórico e Feedbacks
- [ ] Ordens existentes (sem flag) continuam funcionando idênticas
- [ ] `npm run build` passa (✓ confirmado localmente)

## Escopo NÃO incluído (per issue body)

- Filtros novos no Dashboard separando retrabalho vs. não-retrabalho
- KPIs de retrabalho
- Mudanças no fluxo de Metas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
