### PR TITLE
fix: sincronizar animações de loading com o estado real dos saves

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -86,8 +86,9 @@ const ExportModal = ({ open, onClose, format, records, filters, holidays }: Expo
       }
     } catch (e: any) {
       toast.error(e.message || "Erro ao exportar. Tente novamente.");
+    } finally {
+      setExporting(false);
     }
-    setExporting(false);
   }
 
   // Reset sections when format changes (via reopening)

--- a/src/components/FeedbacksTab.tsx
+++ b/src/components/FeedbacksTab.tsx
@@ -59,6 +59,7 @@ const FeedbacksTab = () => {
   async function handleSaveEdit(r: ProdRecord) {
     const key = recordKey(r);
     setSavingKey(key);
+    let ok = false;
     try {
       const nowBR = new Date().toLocaleString("pt-BR");
       await api("upsert", {
@@ -76,19 +77,23 @@ const FeedbacksTab = () => {
           editTime: nowBR,
         }],
       }, user);
+      ok = true;
       toast.success("Observação atualizada!");
       setEditingKey(null);
       setEditText("");
-      await silentRefresh();
     } catch (e: any) {
       toast.error(e.message || "Erro ao salvar");
+    } finally {
+      // Spinner some assim que o api() retorna — silentRefresh roda em background
+      setSavingKey(null);
     }
-    setSavingKey(null);
+    if (ok) silentRefresh().catch(() => {});
   }
 
   async function handleDelete(r: ProdRecord) {
     const key = recordKey(r);
     setSavingKey(key);
+    let ok = false;
     try {
       const nowBR = new Date().toLocaleString("pt-BR");
       await api("upsert", {
@@ -106,13 +111,15 @@ const FeedbacksTab = () => {
           editTime: nowBR,
         }],
       }, user);
+      ok = true;
       toast.success("Observação removida.");
       setDeletingKey(null);
-      await silentRefresh();
     } catch (e: any) {
       toast.error(e.message || "Erro ao excluir");
+    } finally {
+      setSavingKey(null);
     }
-    setSavingKey(null);
+    if (ok) silentRefresh().catch(() => {});
   }
 
   return (

--- a/src/components/ProductionEntry.tsx
+++ b/src/components/ProductionEntry.tsx
@@ -118,6 +118,7 @@ const ProductionEntry = () => {
     if (dateObj < yearAgo) toast.warning("Data muito antiga. Confirme se está correto.");
 
     setSaving(true);
+    let saveOk = false;
     try {
       const nowBR = new Date().toLocaleString("pt-BR");
       const records = Object.values(entries)
@@ -140,13 +141,21 @@ const ProductionEntry = () => {
         });
 
       await api("upsert", { records }, user);
-      setSaved(true);
+      saveOk = true;
       toast.success("Apontamento salvo com sucesso!");
-      await silentRefresh();
     } catch (e: any) {
       toast.error(e.message || "Erro ao salvar");
     } finally {
+      // Encerra o spinner imediatamente após o api() retornar — antes do silentRefresh
       setSaving(false); // P5: always reset, even on session expiry
+    }
+
+    if (saveOk) {
+      // Botão vai direto pra "Salvo!" sem esperar o refresh em background
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
+      // Refresh em background — não bloqueia a UI
+      silentRefresh().catch(() => {});
     }
   }
 

--- a/src/components/ReportsTab.tsx
+++ b/src/components/ReportsTab.tsx
@@ -162,37 +162,45 @@ const ReportsTab = () => {
       setBulkAction(null);
     } catch (e: any) {
       toast.error(e.message || "Erro ao excluir registros");
+    } finally {
+      setBulkLoading(false);
     }
-    setBulkLoading(false);
   }
 
   async function executeBulkMove() {
     if (!bulkMoveDate) { toast.error("Selecione a data destino"); return; }
     setBulkLoading(true);
+    let ok = false;
     try {
       await api("bulkMove", { ids: [...selectedIds], newDate: bulkMoveDate }, user);
-      await silentRefresh();
+      ok = true;
       toast.success(`${selectedIds.size} registro(s) movido(s) para ${dispD(bulkMoveDate)}`);
       setSelectedIds(new Set());
       setBulkAction(null);
     } catch (e: any) {
       toast.error(e.message || "Erro ao mover registros");
+    } finally {
+      // Spinner some assim que o api() retorna — silentRefresh roda em background
+      setBulkLoading(false);
     }
-    setBulkLoading(false);
+    if (ok) silentRefresh().catch(() => {});
   }
 
   async function executeBulkTurno() {
     setBulkLoading(true);
+    let ok = false;
     try {
       await api("bulkEditTurno", { ids: [...selectedIds], newTurno: bulkTurno }, user);
-      await silentRefresh();
+      ok = true;
       toast.success(`${selectedIds.size} registro(s) atualizados para ${bulkTurno}`);
       setSelectedIds(new Set());
       setBulkAction(null);
     } catch (e: any) {
       toast.error(e.message || "Erro ao editar turno");
+    } finally {
+      setBulkLoading(false);
     }
-    setBulkLoading(false);
+    if (ok) silentRefresh().catch(() => {});
   }
 
   return (


### PR DESCRIPTION
## Summary

Closes #4.

Sincroniza as animações de loading com o estado **real** das operações de save. O bug central: `await silentRefresh()` rodava DENTRO do `try`, segurando o `saving=true` por mais alguns segundos depois que o save real já havia terminado. No apontamento, isso fazia a transição "Salvando..." → "Salvo!" ficar emperrada — você via "Salvando..." muito mais tempo do que a operação levava de verdade.

## Princípio aplicado

**O spinner reflete o save, não o refresh.** Assim que o `api()` retorna:
1. Spinner desliga imediatamente (`finally` setSaving(false))
2. UI muda para o estado de sucesso (no apontamento: "Salvo!" verde)
3. `silentRefresh()` roda em background, fora do try/finally — não bloqueia a UI

## Mudanças por arquivo

### `ProductionEntry.tsx` (handleSave)
- Estado "Salvo!" volta automaticamente a "Salvar" depois de 1.5s (antes ficava travado até o usuário mexer em algum campo)
- `silentRefresh()` movido pra fora do try, executado em background com `.catch(() => {})`

### `FeedbacksTab.tsx` (handleSaveEdit, handleDelete)
- `setSavingKey(null)` movido pra `finally` (antes vazava em throw inesperado fora do escopo do catch)
- `silentRefresh()` em background

### `ExportModal.tsx` (handleExport)
- `setExporting(false)` movido pra `finally`

### `ReportsTab.tsx` (executeBulkDelete, executeBulkMove, executeBulkTurno)
- `setBulkLoading(false)` movido pra `finally`
- Move/Turno: `silentRefresh()` em background

## Como testar

1. **Apontar** → preencha uma ordem → **Salvar**
   - "Salvando..." dura só o tempo do request
   - Imediatamente vira "Salvo!" verde
   - Após 1.5s volta a "Salvar"
2. **Feedbacks** → editar obs → **Salvar** → spinner some assim que API responde
3. **Histórico → Tabela** → seleção em massa → **Mover** ou **Mudar turno** → mesmo comportamento
4. Simular erro (devtools → throttle Offline) em qualquer um → spinner ainda desliga, toast de erro aparece

## Test plan

- [ ] Apontamento: animação completa "Salvando..." → "Salvo!" → "Salvar" sem travar
- [ ] Feedbacks: editar/excluir obs → spinner solta imediato
- [ ] Histórico bulk: ações em massa → spinner solta imediato
- [ ] Em todos os fluxos, simular erro de rede → spinner desliga + toast de erro
- [ ] `npm run build` passa (✓ confirmado localmente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
