### PR TITLE
fix: bugs de UI mobile causados pelo navegador

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <!-- TODO: Set the document title to the name of your application -->
     <title>Dashboard WEG</title>
     <meta name="description" content="Lovable Generated Project">

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -18,8 +18,14 @@ const tabs = [
 const BottomNav = ({ activeTab, onTabChange }: BottomNavProps) => {
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 z-50 bg-card/95 backdrop-blur-xl border-t border-border shadow-[0_-4px_20px_rgba(0,0,0,0.08)]"
-      style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+      className="fixed left-0 right-0 z-50 bg-card/95 backdrop-blur-xl border-t border-border shadow-[0_-4px_20px_rgba(0,0,0,0.08)]"
+      // bottom: 0 explícito pra evitar quirk do Safari iOS que reposiciona elementos
+      // fixed durante o scroll. paddingBottom usa max() pra garantir folga mínima
+      // mesmo quando a safe-area do dispositivo retorna 0.
+      style={{
+        bottom: 0,
+        paddingBottom: "max(env(safe-area-inset-bottom), 8px)",
+      }}
     >
       <div className="flex items-stretch h-16">
         {tabs.map((t) => {

--- a/src/components/OrdemProducaoInput.tsx
+++ b/src/components/OrdemProducaoInput.tsx
@@ -34,7 +34,7 @@ const OrdemProducaoInput = ({ ordens, onChange }: OrdemProducaoInputProps) => {
           <input
             type="number"
             inputMode="numeric"
-            placeholder="Quantidade"
+            placeholder="Qtd"
             min={0}
             max={999999}
             value={ordem.quantidade || ""}

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,18 @@
     @apply bg-background text-foreground;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* Safety net: previne scroll horizontal causado por elemento com largura fixa em mobile */
+    overflow-x: hidden;
+  }
+
+  /* Mobile: força font-size mínimo de 16px em campos editáveis para evitar
+   * o auto-zoom que iOS Safari aplica em focus quando o campo tem <16px. */
+  @media (max-width: 639px) {
+    input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+    select,
+    textarea {
+      font-size: 16px;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #3.

Fixes cirúrgicos pra bugs de UI mobile **causados pelo navegador** (sem redesign). Total de 4 alterações em ~10 linhas efetivas.

## Mudanças

### 1. `index.html` — viewport-fit=cover
Sem isso, `env(safe-area-inset-*)` retorna `0` em iOS Safari mesmo com home indicator presente. Habilita o reconhecimento de notch/dynamic island/safe-area.

### 2. `src/index.css` — font-size 16px em campos editáveis em mobile
iOS Safari faz **auto-zoom** quando o usuário foca um input/select/textarea com `font-size < 16px`. Inputs do projeto usavam `text-sm` (14px) em vários lugares (apontamento, busca, observações, login). Regra `@media (max-width: 639px)` força 16px só em mobile, mantém o design desktop intacto.

### 3. `src/index.css` — `body { overflow-x: hidden }`
Safety net contra qualquer elemento com largura fixa que possa gerar scroll horizontal indesejado em viewport 375px.

### 4. `src/components/BottomNav.tsx` — fixed estável em iOS
- `bottom: 0` explícito (em vez de só class `bottom-0`) garante que o Safari não reposicione o elemento durante scroll com URL bar dinâmica.
- `paddingBottom: max(env(safe-area-inset-bottom), 8px)` garante folga mínima de 8px mesmo quando a safe-area do dispositivo é zero.

### 5. `src/components/OrdemProducaoInput.tsx` — placeholder "Quantidade" → "Qtd"
Com a fonte forçada a 16px em mobile (fix #2), o placeholder "Quantidade" estourava o input ficando "Quantidad...". "Qtd" cabe e o contexto (vem ao lado de "Nº OS") deixa claro.

## Como testar

1. Abrir em DevTools → Toggle device toolbar → iPhone 14 Pro
2. Apontar → tocar em qualquer input → confirmar que **NÃO** dá zoom
3. Em qualquer aba mobile, scroll até o fim → BottomNav permanece fixa, sem saltos
4. Confirmar que não aparece scrollbar horizontal em viewport 375px
5. Testar no celular real (HTTP via IP local) — feedback do usuário confirmou OK

## Test plan

- [ ] iOS Safari: toque em select/input não dispara zoom
- [ ] iOS Safari: BottomNav fixa durante scroll com URL bar dinâmica
- [ ] Android Chrome: mesmo comportamento
- [ ] Viewport 375px: nenhum scroll horizontal
- [ ] Desktop ≥ 640px: tudo continua igual (fonte 14px nos inputs preservada)
- [ ] `npm run build` passa (✓ confirmado)

## Escopo NÃO incluído

- Redesign visual mobile
- Performance / refactor
- Outros componentes que possam ter bugs específicos de viewport — esses entram em issue separada se aparecerem

🤖 Generated with [Claude Code](https://claude.com/claude-code)
